### PR TITLE
Use OpenSSL::Digest.new instead of OpenSSL::Digest::Digest.new to avoid ...

### DIFF
--- a/lib/simple-s3/simple-s3.rb
+++ b/lib/simple-s3/simple-s3.rb
@@ -116,7 +116,7 @@ class SimpleS3
     path = ['/','/*','/**/*']
 
     date = Time.now.strftime("%a, %d %b %Y %H:%M:%S %Z")
-    digest = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha1'), aws_secret, date)).strip
+    digest = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), aws_secret, date)).strip
     uri = URI.parse("https://cloudfront.amazonaws.com/2012-07-01/distribution/#{distribution}/invalidation")
 
     path_xml = ''


### PR DESCRIPTION
...deprecation warnings

The current code uses `OpenSSL::Digest::Digest.new('sha1')` - which has been deprecated.  This means you get deprecation warnings for every file that is uploaded to S3:

```
Digest::Digest is deprecated; use Digest
```
